### PR TITLE
Update for crema-0.2.0

### DIFF
--- a/src/java/pom.xml
+++ b/src/java/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ch.idsia</groupId>
             <artifactId>crema</artifactId>
-            <version>0.1.6-isipta21bm-SNAPSHOT</version>
+            <version>0.2.0</version>
             <scope>compile</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.sis/profiles -->

--- a/src/java/src/main/java/ch/idsia/RunCrema.java
+++ b/src/java/src/main/java/ch/idsia/RunCrema.java
@@ -3,31 +3,32 @@ package ch.idsia;
 import ch.idsia.crema.IO;
 import ch.idsia.crema.factor.GenericFactor;
 import ch.idsia.crema.factor.convert.VertexToInterval;
-import ch.idsia.crema.factor.credal.linear.IntervalFactor;
-import ch.idsia.crema.factor.credal.vertex.VertexFactor;
-import ch.idsia.crema.inference.Inference;
+import ch.idsia.crema.factor.credal.linear.interval.IntervalFactor;
+import ch.idsia.crema.factor.credal.vertex.separate.VertexFactor;
 import ch.idsia.crema.inference.approxlp.CredalApproxLP;
 import ch.idsia.crema.inference.ve.CredalVariableElimination;
 import ch.idsia.crema.model.graphical.DAGModel;
+import ch.idsia.crema.utility.GraphUtil;
 import ch.idsia.crema.utility.InvokerWithTimeout;
 import ch.idsia.crema.utility.hull.ConvexHull;
-import ch.idsia.experiments.Convert;
-import ch.javasoft.util.ints.IntHashMap;
 import gnu.trove.map.hash.TIntIntHashMap;
 import org.apache.commons.lang3.time.StopWatch;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-import javax.sound.midi.Soundbank;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import java.util.logging.*;
+import java.util.logging.FileHandler;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 
 /*
@@ -58,7 +59,7 @@ public class RunCrema implements Runnable {
 			InferenceMethod.cve_ch,
 			InferenceMethod.cve_ch5,
 			InferenceMethod.cve_ch10
-		);
+	);
 
 	private final static List<InferenceMethod> LP_METHODS = List.of(
 			InferenceMethod.approxlp,
@@ -71,12 +72,11 @@ public class RunCrema implements Runnable {
 			InferenceMethod.cve_ch5,
 			InferenceMethod.cve_ch10
 	);
-	private static Map<InferenceMethod, ConvexHull.Method> CH_METHODS = Map.ofEntries(
-			Map.entry(InferenceMethod.cve_ch, ConvexHull.Method.LP_CONVEX_HULL),
-			Map.entry(InferenceMethod.cve_ch5, ConvexHull.Method.REDUCED_HULL_5),
-			Map.entry(InferenceMethod.cve_ch10, ConvexHull.Method.REDUCED_HULL_10)
+	private final static Map<InferenceMethod, ConvexHull> CH_METHODS = Map.ofEntries(
+			Map.entry(InferenceMethod.cve_ch, ConvexHull.LP_CONVEX_HULL),
+			Map.entry(InferenceMethod.cve_ch5, ConvexHull.REDUCED_HULL_5),
+			Map.entry(InferenceMethod.cve_ch10, ConvexHull.REDUCED_HULL_10)
 	);
-
 
 
 	/// Command line
@@ -100,101 +100,129 @@ public class RunCrema implements Runnable {
 //	private boolean measureError;
 
 	@Option(names = {"-w", "--warmups"}, description = "Number of warmups (which are not measured). Default is 0.")
-	public void setWarmups(int w){
-		if(w<0) wrongParam("The number of warmups cannot be negative.");
+	public void setWarmups(int w) {
+		if (w < 0) wrongParam("The number of warmups cannot be negative.");
 		warmups = w;
 	}
+
 	private int warmups = 0;
 
 	@Option(names = {"-r", "--runs"}, description = "Number of runs. Default is 1.")
-	public void setRuns(int r){
-		if(r<1) wrongParam("The number of runs cannot be lower than 1.");
+	public void setRuns(int r) {
+		if (r < 1) wrongParam("The number of runs cannot be lower than 1.");
 		runs = r;
 	}
+
 	private int runs = 1;
 
 	@Option(names = {"-T", "--timeout"}, description = "Timeout in seconds. Default is 3600.")
 	private long timeout = 3600;
 
-	@Option(names={"-l", "--log"}, description = "Log file path. If not specified, messages are shown on standard output.")
+	@Option(names = {"-l", "--log"}, description = "Log file path. If not specified, messages are shown on standard output.")
 	String logFile;
 
-	@Option(names = { "-h", "--help" }, usageHelp = true, description = "display a help message")
+	@Option(names = {"-h", "--help"}, usageHelp = true, description = "display a help message")
 	private boolean helpRequested;
 
 
 	@Parameters(description = "Model path in UAI format.")
 	private String modelPath;
 
-	private void wrongParam(String msg){
+	private void wrongParam(String msg) {
 		throw new CommandLine.ParameterException(spec.commandLine(), msg);
 	}
 
 	public static void main(String[] args) {
 		argStr = String.join(";", args);
 		CommandLine.run(new RunCrema(), args);
-		if(errMsg!="")
+		if (errMsg.isEmpty())
 			System.exit(-1);
-
 	}
-
-
 
 	@Override
 	public void run() {
-
 		try {
 			setUp();
 			logger.info("Input args: " + argStr);
 			experiments();
-		}catch (Exception e){
+		} catch (Exception | Error e) {
 			errMsg = e.toString();
 			logger.severe(errMsg);
 			//e.printStackTrace();
-
-		}catch (Error e){
-			errMsg = e.toString();
-			logger.severe(errMsg);
-		}finally {
+		} finally {
 			processResults();
 		}
-
-
-
 	}
 
 	private void experiments() throws IOException, InterruptedException, TimeoutException, ExecutionException {
+		int targetVar = target;
+		TIntIntHashMap evid = new TIntIntHashMap();
+		if(observed != null && observed.length > 0)
+			for (int y : observed)
+				evid.put(y, 0);
+
 		logger.info("Starting experiments");
 
 		// Load the model
-		DAGModel model = (DAGModel) IO.readUAI(modelPath);
-		logger.info("Loaded model "+model.getNetwork());
+		final DAGModel<VertexFactor> model = IO.readUAI(modelPath); // TODO: this assumes that only vertex-based model are loaded
+		logger.info("Loaded model " + model.getNetwork());
 
-		model = preprocessModel(model);
+		final Callable<GenericFactor> task;
 
-		StopWatch watch = new StopWatch();
+		// Set up the inference engine
+		if (VE_METHODS.contains(method)) {
+			final CredalVariableElimination inf = new CredalVariableElimination();
+
+			// Set convex hull
+			if (CH_METHODS.containsKey(method))
+				inf.setConvexHullMarg(CH_METHODS.get(method));
+
+			// CVE works only on VertexFactor models
+			task = () -> inf.query(model, evid, targetVar);
+
+		} else if (LP_METHODS.contains(method)) {
+			if (method == InferenceMethod.intervallp) {
+				DAGModel<IntervalFactor> imodel = new DAGModel<>();
+				GraphUtil.copy(model.getNetwork(), imodel.getNetwork());
+
+				for (int x : imodel.getVariables())
+					imodel.setFactor(x, new VertexToInterval().apply(model.getFactor(x), x));
+
+				// CALP works with any FilterableFactor, there we assume an IntervalFactor model...
+				final CredalApproxLP<IntervalFactor> inf = new CredalApproxLP<>();
+				task = () -> inf.query(imodel, evid, targetVar);
+
+			} else {
+				// ...there instead we assume a VertexFactor model
+				final CredalApproxLP<VertexFactor> inf = new CredalApproxLP<>();
+				task = () -> inf.query(model, evid, targetVar);
+			}
+		} else {
+			throw new IllegalArgumentException("Unknown inference method");
+		}
+
+		final InvokerWithTimeout<GenericFactor> invoker = new InvokerWithTimeout<>();
+		final StopWatch watch = new StopWatch();
 
 		// Run the warmup iterations
-		for(int i=1; i<=warmups; i++) {
+		for (int i = 1; i <= warmups; i++) {
 			watch.reset();
 			watch.start();
-			evaluate(model, method);
+			invoker.run(task, timeout);
 			watch.stop();
-			logger.info("Warmup iteration "+i+"/"+warmups+" ("+watch.getTime()+" ms.)");
+			logger.info("Warmup iteration " + i + "/" + warmups + " (" + watch.getTime() + " ms.)");
 		}
 
 		// Run the measurable experiments
 		time = 0L;
-		for(int i=1; i<=runs; i++) {
+		for (int i = 1; i <= runs; i++) {
 			watch.reset();
 			watch.start();
 
-
-			result = evaluate(model, method);
+			result = invoker.run(task, timeout);
 			watch.stop();
 			time += watch.getTime();
-			logger.info("Measurable iteration "+i+"/"+runs+" ("+watch.getTime()+" ms.)");
-
+			logger.info("Measurable iteration " + i + "/" + runs + " (" + watch.getTime() + " ms.)");
 		}
 
 		/*
@@ -212,71 +240,21 @@ public class RunCrema implements Runnable {
 
 			}
 		}
-
 		 */
-
 	}
 
-	private DAGModel preprocessModel(DAGModel model) {
-		if(method != InferenceMethod.intervallp)
-			return model;
-		DAGModel imodel = model.copy();
-		for(int x : imodel.getVariables())
-			imodel.setFactor(x, (new VertexToInterval()).apply((VertexFactor) model.getFactor(x), x));
-
-		return imodel;
-
-	}
-
-	static Inference inf = null;
-	static TIntIntHashMap evid = null;
-	static int targetVar = 0;
-
-	private GenericFactor evaluate(DAGModel model, InferenceMethod method) throws InterruptedException, TimeoutException, ExecutionException {
-
-
-		// Set up the inference engine
-		if(VE_METHODS.contains(method)){
-			inf = new CredalVariableElimination(model);
-			// Set convex hull
-			if(CH_METHODS.keySet().contains(method))
-				((CredalVariableElimination)inf).setConvexHullMarg(CH_METHODS.get(method));
-		}else if(LP_METHODS.contains(method)){
-			inf = new CredalApproxLP(model);
-		}else{
-			throw new IllegalArgumentException("Unknown inference method");
-
-		}
-
-		targetVar = target;
-		evid = new TIntIntHashMap();
-		//if(observed != null)
-		for(int y : observed)
-			evid.put(y, 0);
-
-		InvokerWithTimeout<GenericFactor> invoker = new InvokerWithTimeout<>();
-		return invoker.run(RunCrema::queryWithTimeout, timeout);
-		//return inf.query(target, evid);
-
-	}
-
-	private static GenericFactor queryWithTimeout() throws InterruptedException {
-		return inf.query(targetVar, evid);
-	}
-
-	private void processResults(){
+	private void processResults() {
 		logger.info("Processing results");
 
 		String msg = "results=dict(";
 
 		ArrayList<String> results = new ArrayList<>();
 
-			if (measureTime)
-				results.add("time=" + (((float) time) / runs));
+		if (measureTime)
+			results.add("time=" + (((float) time) / runs));
 
-
-		if(errMsg.length()==0) {
-			IntervalFactor iresult = null;
+		if (errMsg.length() == 0) {
+			IntervalFactor iresult;
 			if (result instanceof IntervalFactor) {
 				iresult = (IntervalFactor) result;
 			} else if (result instanceof VertexFactor) {
@@ -295,21 +273,19 @@ public class RunCrema implements Runnable {
 									.toArray(String[]::new)) + "]");
 
 			results.add("err_msg=''");
-		}else{
-			results.add("err_msg='"+errMsg+"'");
+		} else {
+			results.add("err_msg='" + errMsg + "'");
 			results.add("interval_result=[]");
 		}
 
-		results.add("arg_str='"+argStr+"'");
-		msg+=String.join(",",results.toArray(String[]::new));
-		msg+=")";
+		results.add("arg_str='" + argStr + "'");
+		msg += String.join(",", results.toArray(String[]::new));
+		msg += ")";
 		logger.info(msg);
 		System.out.println(msg);
-
 	}
 
-	private void setUp(){
-
+	private void setUp() {
 		util.disableWarning();
 
 		logger = Logger.getLogger("MyLog");
@@ -317,7 +293,7 @@ public class RunCrema implements Runnable {
 
 		// This block configure the logger with handler and formatter
 		try {
-			if(logFile == null)
+			if (logFile == null)
 				logFile = File.createTempFile("RunCrema", ".log").getAbsolutePath();
 
 			System.out.println(logFile);
@@ -327,11 +303,10 @@ public class RunCrema implements Runnable {
 			e.printStackTrace();
 		}
 		logger.addHandler(fh);
-		System.setProperty("java.util.logging.SimpleFormatter.format",
-				"[%1$tF_%1$tT][%4$s][java] %5$s%6$s%n");
+		System.setProperty("java.util.logging.SimpleFormatter.format", "[%1$tF_%1$tT][%4$s][java] %5$s%6$s%n");
 		SimpleFormatter formatter = new SimpleFormatter();
 		fh.setFormatter(formatter);
-		logger.info("Saving log to: "+logFile);
+		logger.info("Saving log to: " + logFile);
 	}
 
 }

--- a/src/java/src/main/java/ch/idsia/experiments/Convert.java
+++ b/src/java/src/main/java/ch/idsia/experiments/Convert.java
@@ -1,18 +1,18 @@
 package ch.idsia.experiments;
 
 import ch.idsia.crema.factor.convert.HalfspaceToVertex;
-import ch.idsia.crema.factor.credal.linear.SeparateHalfspaceFactor;
-import ch.idsia.crema.factor.credal.vertex.VertexFactor;
+import ch.idsia.crema.factor.credal.linear.separate.SeparateHalfspaceFactor;
 import ch.idsia.crema.core.Strides;
+import ch.idsia.crema.factor.credal.linear.separate.SeparateHalfspaceFactorFactory;
+import ch.idsia.crema.factor.credal.vertex.separate.VertexFactor;
 import ch.idsia.crema.model.graphical.DAGModel;
 import ch.idsia.crema.utility.ArraysUtil;
+import ch.idsia.crema.utility.GraphUtil;
 import ch.idsia.util;
 import org.apache.commons.math3.optim.linear.Relationship;
 
 import java.io.*;
 import java.nio.file.InvalidPathException;
-import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -22,26 +22,20 @@ public class Convert {
 
     public static String libPath = "./lib/";
 
-
     public static SeparateHalfspaceFactor vertexToHspace(VertexFactor factor) throws IOException, InterruptedException {
 
-
-        SeparateHalfspaceFactor HF = new SeparateHalfspaceFactor(factor.getDataDomain(), factor.getSeparatingDomain());
+        SeparateHalfspaceFactorFactory shff = SeparateHalfspaceFactorFactory.factory().domain(factor.getDomain(), factor.getSeparatingDomain());
 
         for(int i=0; i<factor.getSeparatingDomain().getCombinations(); i++) {
-            VertexFactor VFi = new VertexFactor(factor.getDataDomain(), Strides.empty(), new double[][][]{factor.getData()[i]});
+            final VertexFactor VFi = factor.getSingleVertexFactor(i);// TODO: check if this is the desired value
             SeparateHalfspaceFactor HFi = Convert.margVertexToHspace(VFi);
-            HF.setLinearProblemAt(i, HFi.getLinearProblemAt(0));
+            shff.linearProblemAt(i, HFi.getLinearProblemAt(0));
         }
 
-        return HF;
-
+        return shff.get();
     }
 
-
     public static SeparateHalfspaceFactor margVertexToHspace(VertexFactor factor) throws IOException, InterruptedException {
-
-
         if(factor.getSeparatingDomain().getSize()>0)
             throw new IllegalArgumentException("input factor must have no parents");
 
@@ -49,8 +43,6 @@ public class Convert {
 
         if(!new File(polco_jar).exists())
             throw new InvalidPathException(polco_jar, "Polco jar not found");
-
-
 
         int numVert = factor.getData()[0].length;
         int numDim = factor.getDataDomain().getCombinations();
@@ -61,28 +53,25 @@ public class Convert {
                 return lineVertexToHspace(factor);
             } else {
                 throw new IllegalArgumentException("The number of vertices cannot be lower than the cardinality");
-
             }
         }
 
         // build .ext file
-        String extContent = "V-representation\n" +
-                "begin\n"+(numVert)+" "+(numDim+1)+" real\n";
+        StringBuilder extContent = new StringBuilder("V-representation\nbegin\n" + (numVert) + " " + (numDim + 1) + " real\n");
 
         for(double[] v : factor.getData()[0]){
-            extContent += "1"+ DoubleStream.of(v)
-                    .mapToObj(d -> " "+Double.toString(d))
-                    .collect(Collectors.joining())+"\n";
+            extContent.append("1").append(DoubleStream.of(v)
+                    .mapToObj(d -> " " + d)
+                    .collect(Collectors.joining())).append("\n");
         }
 
-        extContent +="end\n";
-        extContent += "hull\n";
-        extContent += "incidence\n";
-
+        extContent.append("end\n");
+        extContent.append("hull\n");
+        extContent.append("incidence\n");
 
         File extFile = File.createTempFile("factor", ".ext");
         FileWriter writer = new FileWriter(extFile);
-        writer.write(extContent);
+        writer.write(extContent.toString());
         writer.close();
 
         // Create output file
@@ -93,16 +82,14 @@ public class Convert {
                 " -kind cdd -in "+extFile.getAbsolutePath()+
                 " -out text "+outFile.getAbsolutePath();
 
-
         Process p = Runtime.getRuntime().exec(cmd);
         p.waitFor();
 
         if(p.exitValue()>0)
             throw new RuntimeException("problem with bash command.");
 
-
         // read generated txt file and build the inequalities
-        SeparateHalfspaceFactor hf = new SeparateHalfspaceFactor(factor.getDomain(), Strides.empty());
+        SeparateHalfspaceFactorFactory shff = SeparateHalfspaceFactorFactory.factory().domain(factor.getDomain(), Strides.empty());
 
         //Ax <= b
         for(String l : new BufferedReader(new FileReader(outFile)).lines().toArray(String[]::new)){
@@ -117,25 +104,24 @@ public class Convert {
                     A[i - 1] *= -1;
             }
 
-            hf.addConstraint(A, Relationship.LEQ, b);
-
+            shff.constraint(A, Relationship.LEQ, b);
         }
 
         // Non-negativ constraints
         for(int i=0; i<numDim; i++){
             double[] A = new double[numDim];
             A[i] = 1;
-            hf.addConstraint(A, Relationship.GEQ, 0.0);
+            shff.constraint(A, Relationship.GEQ, 0.0);
         }
 
         // normalization constraint
-        hf.addConstraint(
+        shff.constraint(
                 IntStream.range(0,numDim).mapToDouble(i -> 1.0).toArray(),
                 Relationship.EQ,
                 1.0
         );
 
-        return hf;
+        return shff.get();
 
     }
 
@@ -147,14 +133,13 @@ public class Convert {
         if(!new File(py_script).exists())
             throw new InvalidPathException(py_script, "Python script not found");
 
-        String cmd = "python " + py_script;
+        StringBuilder cmd = new StringBuilder("python " + py_script);
 
         for (double[] p : points) {
-            for (int i = 0; i < p.length; i++)
-                cmd += " " + p[i];
+            for (double v : p) cmd.append(" ").append(v);
         }
 
-        Process p = Runtime.getRuntime().exec(cmd);
+        Process p = Runtime.getRuntime().exec(cmd.toString());
         p.waitFor();
 
         if (p.exitValue() > 0)
@@ -163,15 +148,22 @@ public class Convert {
         String output = new BufferedReader(new InputStreamReader(p.getInputStream())).readLine();
 
         // b -A
-        return Stream.of(output.split("\t")).mapToDouble(s -> Double.parseDouble(s)).toArray();
+        return Stream.of(output.split("\t")).mapToDouble(Double::parseDouble).toArray();
+    }
+
+    private static class LineConstraintMatrix {
+        double[][] A;
+        double[] b;
+
+        public LineConstraintMatrix(double[][] a, double[] b) {
+            A = a;
+            this.b = b;
+        }
     }
 
     public static SeparateHalfspaceFactor lineVertexToHspace(VertexFactor factor) throws IOException, InterruptedException {
-
-
         if(factor.getSeparatingDomain().getSize()>0)
             throw new IllegalArgumentException("input factor must have no parents");
-
 
         // Check number of vertices
         int numVert = factor.getData()[0].length;
@@ -181,16 +173,15 @@ public class Convert {
             throw new IllegalArgumentException("Too many vertices");
 
         // Get the constraints
-        List out = getLineConstMatrix(factor.getData()[0]);
-        double[] b = (double[]) out.get(0);
-        double[][] A = (double[][]) out.get(1);
+        LineConstraintMatrix out = getLineConstMatrix(factor.getData()[0]);
+        double[] b = out.b;
+        double[][] A = out.A;
 
         // Define the H-factor
-        SeparateHalfspaceFactor hf = new SeparateHalfspaceFactor(factor.getDomain(), Strides.empty());
+        SeparateHalfspaceFactorFactory shff = SeparateHalfspaceFactorFactory.factory().domain(factor.getDomain(), Strides.empty());
 
         for(int i=0; i<A.length; i++)
-            hf.addConstraint(A[i], Relationship.EQ, b[i]);
-
+            shff.constraint(A[i], Relationship.EQ, b[i]);
 
         // Bound constraints
         for(int i=0; i<numDim; i++){
@@ -198,27 +189,24 @@ public class Convert {
             Ai[i] = 1;
             double[] bounds = {factor.getData()[0][0][i],factor.getData()[0][1][i]};
             if(bounds[0] != bounds[1]) {
-                hf.addConstraint(Ai, Relationship.GEQ, Math.min(bounds[0], bounds[1]));
-                hf.addConstraint(Ai, Relationship.LEQ, Math.max(bounds[0], bounds[1]));
+                shff.constraint(Ai, Relationship.GEQ, Math.min(bounds[0], bounds[1]));
+                shff.constraint(Ai, Relationship.LEQ, Math.max(bounds[0], bounds[1]));
             }else{
-                hf.addConstraint(Ai, Relationship.EQ, bounds[0]);
+                shff.constraint(Ai, Relationship.EQ, bounds[0]);
             }
         }
 
         // normalization constraint
-        hf.addConstraint(
+        shff.constraint(
                 IntStream.range(0,numDim).mapToDouble(i -> 1.0).toArray(),
                 Relationship.EQ,
                 1.0
         );
 
-
-        return hf;
+        return shff.get();
     }
 
-
-    private static List getLineConstMatrix(double[][] vert) throws IOException, InterruptedException {
-
+    private static LineConstraintMatrix getLineConstMatrix(double[][] vert) throws IOException, InterruptedException {
         // remove constant dimensions
         int[] nonConst =
                 IntStream.range(0, vert[0].length)
@@ -233,15 +221,12 @@ public class Convert {
         double[][] A = new double[numConst][dim];
         double[] b = new double[numConst];
 
-
         for(int s=0; s<numConst; s++) {
             double[] vals =  lstsq(ArraysUtil.sliceColumns(V, s, s + 1));
             b[s] = vals[0];
             double[] A_s = IntStream.range(1,vals.length).mapToDouble(i-> -1*vals[i]).toArray();
-            for(int i=0; i<A_s.length; i++)
-                A[s][i+s] = A_s[i];
+            System.arraycopy(A_s, 0, A[s], s, A_s.length);
         }
-
 
         double[][] Aexp = new double[numConst][vert[0].length];
         for(int i=0; i<A.length; i++){
@@ -250,47 +235,51 @@ public class Convert {
             }
         }
 
-        return Arrays.asList(b, Aexp);
+        return new LineConstraintMatrix(Aexp, b);
     }
 
-    public static DAGModel VmodelToHmodel(DAGModel vmodel) throws IOException, InterruptedException {
+    public static DAGModel<SeparateHalfspaceFactor> VmodelToHmodel(DAGModel<VertexFactor> vmodel) throws IOException, InterruptedException {
 
-        DAGModel hmodel = (DAGModel) vmodel.copy();
+        DAGModel<SeparateHalfspaceFactor> hmodel = new DAGModel<>();
+
+        // copy structure
+        GraphUtil.copy(vmodel.getNetwork(), hmodel.getNetwork());
+
         int[] variables = vmodel.getVariables();
 
         for (int x : variables) {
-            SeparateHalfspaceFactor hf = Convert.vertexToHspace((VertexFactor) vmodel.getFactor(x));
+            SeparateHalfspaceFactor hf = Convert.vertexToHspace(vmodel.getFactor(x));
             hmodel.setFactor(x, hf);
         }
         return hmodel;
     }
 
-    @SuppressWarnings("all")
-    public static DAGModel HmodelToVmodel(DAGModel hmodel) throws IOException, InterruptedException {
+    public static DAGModel<VertexFactor> HmodelToVmodel(DAGModel<SeparateHalfspaceFactor> hmodel) throws IOException, InterruptedException {
 
-        DAGModel vmodel = (DAGModel) hmodel.copy();
+        DAGModel<VertexFactor> vmodel = new DAGModel<>();
+
+        // copy structure
+        GraphUtil.copy(hmodel.getNetwork(), vmodel.getNetwork());
+
         int[] variables = hmodel.getVariables();
 
         for (int x : variables) {
-            VertexFactor vf = (new HalfspaceToVertex()).apply((SeparateHalfspaceFactor) hmodel.getFactor(x), x);
+            VertexFactor vf = new HalfspaceToVertex().apply(hmodel.getFactor(x), x);
             vmodel.setFactor(x, vf);
         }
         return vmodel;
     }
 
-    public static boolean isConvertible(VertexFactor vf, int leftVar) throws IOException, InterruptedException {
+    public static boolean isConvertible(VertexFactor vf, int leftVar) {
         VertexFactor vf2 = null;
         boolean convertible = true;
         try {
             vf2 = new HalfspaceToVertex().apply(Convert.margVertexToHspace(vf), leftVar);
-        }catch (Exception e){
+        } catch (Exception e){
             convertible = false;
         }
 
         return convertible && vf2 != null;
     }
-
-
-
 
 }

--- a/src/java/src/main/java/ch/idsia/experiments/Example.java
+++ b/src/java/src/main/java/ch/idsia/experiments/Example.java
@@ -1,4 +1,5 @@
 package ch.idsia.experiments;
+
 import ch.idsia.crema.factor.bayesian.BayesianFactor;
 import ch.idsia.crema.model.graphical.DAGModel;
 import ch.idsia.crema.model.io.bif.XMLBIFParser;
@@ -6,7 +7,6 @@ import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 public class Example {
@@ -19,7 +19,5 @@ public class Example {
         DAGModel<BayesianFactor> model = (DAGModel<BayesianFactor>) parser.parse(fio);
 
         System.out.println(model);
-
-
     }
 }

--- a/src/java/src/main/java/ch/idsia/experiments/benchmark/Evaluation.java
+++ b/src/java/src/main/java/ch/idsia/experiments/benchmark/Evaluation.java
@@ -1,19 +1,21 @@
 package ch.idsia.experiments.benchmark;
 
 
+import ch.idsia.crema.factor.FilterableFactor;
+import ch.idsia.crema.factor.GenericFactor;
 import ch.idsia.crema.inference.approxlp.CredalApproxLP;
 import ch.idsia.crema.model.graphical.DAGModel;
 import gnu.trove.map.hash.TIntIntHashMap;
 
 import java.util.concurrent.Callable;
 
-public class Evaluation implements Callable<Boolean> {
+public class Evaluation<F extends FilterableFactor<F>> implements Callable<Boolean> {
 
-	DAGModel hmodel;
+	DAGModel<F> hmodel;
 	int target;
 	TIntIntHashMap evidence;
 
-	public Evaluation(DAGModel hmodel, int target, TIntIntHashMap evidence){
+	public Evaluation(DAGModel<F> hmodel, int target, TIntIntHashMap evidence){
 		this.hmodel = hmodel;
 		this.target = target;
 		this.evidence = evidence;
@@ -22,8 +24,8 @@ public class Evaluation implements Callable<Boolean> {
 	public Boolean call() throws InterruptedException {
 		boolean eval = true;
 		try {
-			CredalApproxLP inf = new CredalApproxLP(hmodel);
-			inf.query(target, evidence);
+			CredalApproxLP<F> inf = new CredalApproxLP<>();
+			inf.query(hmodel, evidence, target);
 		}catch (Exception e){
 			//e.printStackTrace();
 			eval = false;

--- a/src/java/src/main/java/ch/idsia/experiments/benchmark/GenHmodels.java
+++ b/src/java/src/main/java/ch/idsia/experiments/benchmark/GenHmodels.java
@@ -1,14 +1,15 @@
 package ch.idsia.experiments.benchmark;
 
 import ch.idsia.crema.IO;
-import ch.idsia.crema.factor.credal.linear.SeparateHalfspaceFactor;
-import ch.idsia.crema.factor.credal.vertex.VertexFactor;
+import ch.idsia.crema.factor.credal.linear.separate.SeparateHalfspaceFactor;
+import ch.idsia.crema.factor.credal.vertex.separate.VertexFactor;
 import ch.idsia.crema.model.graphical.DAGModel;
 import ch.idsia.experiments.Convert;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,26 +23,25 @@ public class GenHmodels {
         String vmodelFolder = prj_dir+"/networks/vmodel/";
         String hmodelFolder = prj_dir+"/networks/hmodel/";
 
-        ArrayList<String> failed = new ArrayList<String>();
+        List<String> failed = new ArrayList<>();
         List<String> files = getFiles(vmodelFolder);
 
         boolean rewrite = false;
-
 
         int i = 1;
         for(String vfile : files) {
             try {
                 // Load the vmodel
-                System.out.println("Processing "+(i++)+"/"+files.size());
+                System.out.println("Processing " + (i++) + "/" + files.size());
                 System.out.println(vfile);
                 String name = vfile.substring(vfile.lastIndexOf("/") + 1).replace("vmodel", "hmodel");
 
-
-                if (rewrite || !new File(hmodelFolder + "" + name).exists()) {
-
-                    DAGModel vmodel = (DAGModel) IO.read(vfile);
+                final File file = new File(hmodelFolder + "" + name);
+                if (rewrite || !file.exists()) {
+                    // TODO: assuming that "vmodel" is for VertexFactor models, and "hmodel" are for SeparateHalfspaceFactor
+                    DAGModel<VertexFactor> vmodel = IO.read(vfile);
                     // Convert the model
-                    DAGModel hmodel = buildHmodel(vmodel);
+                    DAGModel<SeparateHalfspaceFactor> hmodel = buildHmodel(vmodel);
 
                     // Save the hmodel
                     System.out.println("Saving " + hmodelFolder + "" + name);
@@ -57,10 +57,7 @@ public class GenHmodels {
 
         System.out.println("\nFailed:\n===============");
         failed.forEach(System.out::println);
-
-
     }
-
 
     public static List<String> getFiles(String folder) throws IOException {
         return StreamSupport
@@ -68,13 +65,12 @@ public class GenHmodels {
                         Paths.get(folder),
                         path -> path.toString().endsWith(".uai") && path.toString().contains("vmodel-")
                 ).spliterator(), false)
-                .map(f -> f.toString())
+                .map(Path::toString)
                 .collect(Collectors.toList());
     }
 
-
-    public static DAGModel buildHmodel(DAGModel vmodel) throws IOException, InterruptedException {
-        System.out.println("Converting "+vmodel.getVariables().length+" v-factors");
+    public static DAGModel<SeparateHalfspaceFactor> buildHmodel(DAGModel<VertexFactor> vmodel) throws IOException, InterruptedException {
+        System.out.println("Converting " + vmodel.getVariables().length + " v-factors");
         return Convert.VmodelToHmodel(vmodel);
     }
 

--- a/src/java/src/main/java/ch/idsia/experiments/benchmark/GenStructure.java
+++ b/src/java/src/main/java/ch/idsia/experiments/benchmark/GenStructure.java
@@ -20,7 +20,6 @@ public class GenStructure {
         int[] maxInDegree = {2,4,6};
         int[] maxValues = {4}; // binary and ternary variables
 
-
         for(int n: numNodes){
             for(int mID: maxInDegree){
                 for(int mD: maxDegree){
@@ -32,10 +31,6 @@ public class GenStructure {
                 }
             }
         }
-
-
-
-
     }
 
     public static void generate(String structure, int n, int mID, int mD, int mV) throws Exception {
@@ -52,14 +47,11 @@ public class GenStructure {
         // Set random seed
         System.out.println(param_str.hashCode());
 
-
-
         //// Generation process /////
         // Optional parameters
-        Map kwargs = new HashMap<String, String>();
+        Map<String, String> kwargs = new HashMap<>();
         kwargs.put("maxInducedWidth", String.valueOf(maxInducedWidth));
         kwargs.put("nGraphs", String.valueOf(nGraphs));
-
 
         // start
         gen.generate(structure, mV, baseFileName, format, kwargs);

--- a/src/java/src/main/java/ch/idsia/util.java
+++ b/src/java/src/main/java/ch/idsia/util.java
@@ -1,24 +1,17 @@
 package ch.idsia;
 
-import org.apache.commons.lang3.math.Fraction;
 import sun.misc.Unsafe;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public class util {
-    public static double parseDouble(String s){
-        if (s.contains("/")){
+    public static double parseDouble(String s) {
+        if (s.contains("/")) {
             String[] frac = s.split("/");
-            return Double.valueOf(frac[0]) / Double.valueOf(frac[1]);
+            return Double.parseDouble(frac[0]) / Double.parseDouble(frac[1]);
             //  return Fraction.getFraction(s).doubleValue();
         }
-        return Double.valueOf(s);
+        return Double.parseDouble(s);
     }
 
     public static void disableWarning() {
@@ -27,7 +20,7 @@ public class util {
             theUnsafe.setAccessible(true);
             Unsafe u = (Unsafe) theUnsafe.get(null);
 
-            Class cls = Class.forName("jdk.internal.module.IllegalAccessLogger");
+            Class<?> cls = Class.forName("jdk.internal.module.IllegalAccessLogger");
             Field logger = cls.getDeclaredField("logger");
             u.putObjectVolatile(cls, u.staticFieldOffset(logger), null);
         } catch (Exception e) {


### PR DESCRIPTION
As requested, I updated the Java code to be compatible with the new `crema-0.2.0` version. I left some `TODO` in places where I don't know the behavior of the software.

One major concern I have is that we don't know the type of the models when we load them without assuming it or using generic `DAGModel<?>` and `DAGModel<GenericFactor>` types. What happen when a user load a _BayesianNetwork_ (`DAGModel<BayesianFactor`) but the software expects a `DAGModel<VertexFactor>`?
This is an issue that we should solve in crema.



I didn't tested this before use it since I haven't found any test or documentation. Please check that everything is working accordingly before merge the changes.